### PR TITLE
Removed redundant raise

### DIFF
--- a/lib/coderay/helpers/plugin.rb
+++ b/lib/coderay/helpers/plugin.rb
@@ -176,7 +176,6 @@ module CodeRay
         id = validate_id(plugin_id)
         path = path_to id
         begin
-          raise LoadError, "#{path} not found" unless File.exist? path
           require path
         rescue LoadError => boom
           if @plugin_map_loaded


### PR DESCRIPTION
It's covered by the require which raises a LoadError if the file does not exist
