### PR TITLE
add license information to gemspec

### DIFF
--- a/coderay.gemspec
+++ b/coderay.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |s|
   s.rubyforge_project = s.name
   s.rdoc_options      = '-SNw2', "-m#{readme_file}", '-t CodeRay Documentation'
   s.extra_rdoc_files  = readme_file
+  s.license = "MIT"
 end


### PR DESCRIPTION
This way it can be queried using the rubygems.org API
