### PR TITLE
c# and xaml extension aliases

### DIFF
--- a/lib/coderay/helpers/file_type.rb
+++ b/lib/coderay/helpers/file_type.rb
@@ -122,10 +122,11 @@ module CodeRay
       'tmproj'   => :xml,
       'xhtml'    => :html,
       'xml'      => :xml,
+      'xaml'     => :xml,
       'yaml'     => :yaml,
       'yml'      => :yaml,
     }
-    for cpp_alias in %w[cc cpp cp cxx c++ C hh hpp h++ cu]
+    for cpp_alias in %w[cc cpp cp cxx c++ C hh hpp h++ cu cs]
       TypeFromExt[cpp_alias] = :cpp
     end
     


### PR DESCRIPTION
Hi, this modification makes .cs (c#) and .xaml files look prettier (actually in redmine, which depends on coderay). Hope you'll accept it.
