### PR TITLE
Support for phtml FileType

### DIFF
--- a/lib/coderay/helpers/file_type.rb
+++ b/lib/coderay/helpers/file_type.rb
@@ -99,7 +99,7 @@ module CodeRay
       'mab'      => :ruby,
       'pas'      => :delphi,
       'patch'    => :diff,
-      'phtml'    => :html,
+      'phtml'    => :php,
       'php'      => :php,
       'php3'     => :php,
       'php4'     => :php,


### PR DESCRIPTION
In most cases, phtml files are html/javascripts with small PHP content. 

I regesitered the filetype.
