### PR TITLE
LTSV scanner

### DIFF
--- a/lib/coderay/helpers/file_type.rb
+++ b/lib/coderay/helpers/file_type.rb
@@ -96,6 +96,7 @@ module CodeRay
       'java'     => :java,
       'js'       => :java_script,
       'json'     => :json,
+      'ltsv'     => :ltsv,
       'mab'      => :ruby,
       'pas'      => :delphi,
       'patch'    => :diff,

--- a/lib/coderay/scanners/ltsv.rb
+++ b/lib/coderay/scanners/ltsv.rb
@@ -1,0 +1,49 @@
+module CodeRay
+module Scanners
+
+  # A scanner for LTSV.
+  # http://ltsv.org
+  class Ltsv < Scanner
+
+    register_for :ltsv
+    file_extension 'ltsv'
+
+  protected
+
+    def scan_tokens encoder, options
+
+      state = :initial
+
+      until eos?
+
+        if match = scan(/(?:\r?\n)+/)
+          encoder.text_token match, :space
+          state = :initial if match.index(/\r?\n/)
+
+        elsif (state == :initial || state == :tab) && match = scan(/[^:]+/)
+          encoder.text_token match, :key
+          state = :label
+
+        elsif state == :label && match = scan(/:/)
+          encoder.text_token match, :delimiter
+          state = :colon
+
+        elsif state == :colon && match = scan(/[^\t\r\n]*/)
+          encoder.text_token match, :value
+          state = :value
+
+        elsif state == :value && match = scan(/\t/)
+          encoder.text_token match, :space
+          state = :tab
+
+        else
+          raise
+        end
+      end
+
+      encoder
+    end
+  end
+
+end
+end


### PR DESCRIPTION
I've written a Coderay scanner for [LTSV (Labeled Tab-Separated Values)](http://ltsv.org/) which is a text format like below:

``` plain
host:127.0.0.1<TAB>ident:-<TAB>user:frank<TAB>time:[10/Oct/2000:13:55:36 -0700]<TAB>req:GET /apache_pb.gif HTTP/1.0<TAB>status:200<TAB>size:2326<TAB>referer:http://www.example.com/start.html<TAB>ua:Mozilla/4.08 [en] (Win98; I ;Nav)
```

It is mainly used for logs and actually supported by [fluentd](http://fluentd.org/), a log collector.

I use this format for logging web servers and applications, and watching it with [ltsview](https://github.com/naoto/ltsview), but it is difficult to recognize labels or values. So I wrote the scanner to color them.

Thanks.
