### PR TITLE
Support CDATA blocks in HTML/XML

### DIFF
--- a/lib/coderay/scanners/html.rb
+++ b/lib/coderay/scanners/html.rb
@@ -99,7 +99,17 @@ module Scanners
           case state
           
           when :initial
-            if match = scan(/<!--(?:.*?-->|.*)/m)
+            if match = scan(/<!\[CDATA\[/)
+              encoder.begin_group :string
+              encoder.text_token match, :delimiter
+              if match = scan(/.*?\]\]>/m)
+                encoder.text_token match[0..-4], :content
+                encoder.text_token ']]>', :delimiter
+              else
+                encoder.text_token scan(/.*/m), :error
+              end
+              encoder.end_group :string
+            elsif match = scan(/<!--(?:.*?-->|.*)/m)
               encoder.text_token match, :comment
             elsif match = scan(/<!(\w+)(?:.*?>|.*)|\]>/m)
               encoder.text_token match, :doctype


### PR DESCRIPTION
Currently XML with CDATA blocks parses with an error:

```
<r><![CDATA[
  This is valid, but the open and close angle brackes are flagged as errors.
]]></r>
```

This pull request modifies the HTML scanner (since the XML scanner just defers to that) to add CDATA block scanning. The block is tagged with a `:string` group with the opening `<![CDATA[` and closing `]]>` marked as `:delimiter` and the contents as `:content`.

If a CDATA block starts but is never closed, all content following the opening delimiter are tagged with `:error`.
