### PR TITLE
Add Ruby 2.4.0 test to Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
   - 2.1
   - 2.2
   - 2.3.0
+  - 2.4.0
   - ruby-head
   - jruby-18mode
   - jruby-19mode


### PR DESCRIPTION
Is it possible to add Ruby 2.4.0 to Travis?

I could pass the test on my local environment.

```
$ ruby -v
ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-linux]

$ bundle -v
Bundler version 1.13.7

$ bundle install --path vendor/bundle

$ bundle list
Gems included by the bundle:
  * RedCloth (4.3.2)
  * bundler (1.13.7)
  * coderay (1.1.1.rc1)
  * power_assert (0.4.1)
  * rake (10.5.0)
  * rdoc (5.0.0)
  * shoulda-context (1.2.2)
  * term-ansicolor (1.4.0)
  * test-unit (3.2.3)
  * tins (1.6.0)

$ bundle exec rake test
```


