### PR TITLE
Add an explicit method to retrieve supported languages.

### DIFF
--- a/lib/coderay.rb
+++ b/lib/coderay.rb
@@ -279,6 +279,20 @@ module CodeRay
       options.fetch :scanner_options, {}
     end
     
+    # Provide a list of supported code languages.
+    #
+    # Returns a hash of symbols.
+    def supported_languages(include_aliases=true, include_internals=false)
+      languages = CodeRay::Scanners.list
+      if include_aliases == true
+        languages += CodeRay::Scanners.plugin_hash.keys.map(&:to_sym)
+      end
+      if include_internals == false
+        languages -= %w(debug default raydebug scanner).map(&:to_sym)
+      end
+      return languages
+    end
+    
   end
   
 end

--- a/test/functional/basic.rb
+++ b/test/functional/basic.rb
@@ -155,6 +155,40 @@ more code  # and another comment, in-line.
     assert CodeRay::Scanners.list.include?(:text)
   end
   
+  def test_supported_languages_should_return_array_of_symbols
+    assert_kind_of(Array, CodeRay.supported_languages)
+    assert_kind_of(Symbol, CodeRay.supported_languages.first)
+  end
+  
+  def test_supported_languages_should_include_languages
+    assert_includes CodeRay.supported_languages, :ruby
+  end
+  
+  def test_supported_languages_without_arguments_should_include_aliases_and_exclude_internals
+    assert_includes CodeRay.supported_languages, :javascript
+    refute_includes CodeRay.supported_languages, :debug
+  end
+  
+  def test_supported_languages_with_arguments_should_include_aliases_and_exclude_internals
+    assert_includes CodeRay.supported_languages(true, false), :javascript
+    refute_includes CodeRay.supported_languages(true, false), :debug
+  end
+  
+  def test_supported_languages_with_arguments_should_exclude_aliases_and_include_internals
+    refute_includes CodeRay.supported_languages(false, true), :javascript
+    assert_includes CodeRay.supported_languages(false, true), :debug
+  end
+  
+  def test_supported_languages_with_arguments_should_include_aliases_and_internals
+    assert_includes CodeRay.supported_languages(true, true), :javascript
+    assert_includes CodeRay.supported_languages(true, true), :debug
+  end
+  
+  def test_supported_languages_with_arguments_should_exclude_aliases_and_internals
+    refute_includes CodeRay.supported_languages(false, false), :javascript
+    refute_includes CodeRay.supported_languages(false, false), :debug
+  end
+  
   def test_token_kinds
     assert_kind_of Hash, CodeRay::TokenKinds
     for kind, css_class in CodeRay::TokenKinds


### PR DESCRIPTION
The current way of retrieving a list of supported languages from CodeRay (using `CodeRay::Scanners.list`, see eg. the Stack Overflow question '[Getting the list of available languages](https://stackoverflow.com/q/36860395)') has two drawbacks/limitations:
1. it includes "internal" scanners which aren't representing actual languages (`debug`, `raydebug`, `scanner` and potentially the `default` alias);
2. it does not include language aliases.

I can think of multiple use-cases where one wants to retrieve a list of supported languages, excluding the "internal" scanners and/or including the aliases. One is for example reported as #194.

Recently, Redmine introduced a change where such a list is needed too (revisions [r16501](http://www.redmine.org/projects/redmine/repository/revisions/16501) and [r16502](http://www.redmine.org/projects/redmine/repository/revisions/16502)). While it is pretty easy to "generate" it downstream (redmine.org issues [#25634](http://www.redmine.org/issues/25634) and [#26055](http://www.redmine.org/issues/26055)), it requires CodeRay integrators to reinvent the wheel over-and-over again. As such I think it would be handy if this functionality is provided by the CodeRay API itself.

I extracted a new, generalized class method (`CodeRay.supported_languages`) from the Redmine core, ported it to CodeRay and added some basic test coverage. The method has two optional arguments:
1. `include_aliases` (default to `true`);
2. `include_internals` (default to `false`).

These defaults are taken from Redmine's use-case and, as such, may not suit everyone's needs.
