### PR TITLE
Get tests running with frozen string literals.

### DIFF
--- a/lib/coderay/encoders/encoder.rb
+++ b/lib/coderay/encoders/encoder.rb
@@ -146,7 +146,7 @@ module CodeRay
       end
       
       def get_output options
-        options[:out] || ''
+        options[:out] || ''.dup
       end
       
       # Append data.to_s to the output. Returns the argument.

--- a/lib/coderay/encoders/html.rb
+++ b/lib/coderay/encoders/html.rb
@@ -176,7 +176,7 @@ module Encoders
       
       if options[:wrap] || options[:line_numbers]
         @real_out = @out
-        @out = ''
+        @out = ''.dup
       end
       
       @break_lines = (options[:break_lines] == true)
@@ -314,7 +314,7 @@ module Encoders
     end
     
     def break_lines text, style
-      reopen = ''
+      reopen = ''.dup
       @opened.each_with_index do |kind, index|
         reopen << (@span_for_kinds[index > 0 ? [kind, *@opened[0...index]] : kind] || '<span>')
       end


### PR DESCRIPTION
These changes ensure that all string literals can be frozen (as per the optional feature in MRI 2.3 and onwards).

I would recommend adding the following to your .travis.yml file to ensure regressions aren't introduced:

```yml
before_script:
- if (ruby -e "exit RUBY_VERSION.to_f >= 2.4"); then export RUBYOPT="--enable-frozen-string-literal"; fi; echo $RUBYOPT
```

This will add the flag when the tests are run on MRI 2.4 or newer (while the feature was introduced in 2.3, it doesn't seem to work reliably until 2.4). Note that to get the test suite passing in that situation, you'll need the latest `test-unit` release (3.2.5), because that's now also frozen-string-literal compatible.