### PR TITLE
Update Ruby 2.5 to 2.5.1 and add Ruby 2.6 on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ rvm:
   - 2.2
   - 2.3
   - 2.4.2
-  - 2.5
+  - 2.5.1
+  - 2.6
   - ruby-head
   - jruby
 branches:
@@ -20,7 +21,7 @@ before_script:
 - if (ruby -e "exit RUBY_VERSION.to_f >= 2.3"); then export RUBYOPT="--enable-frozen-string-literal"; fi; echo $RUBYOPT
 matrix:
   allow_failures:
-    - rvm: 2.5
+    - rvm: 2.6
     - rvm: ruby-head
     - rvm: jruby
 script: "rake test" # test:scanners"


### PR DESCRIPTION
I updated Ruby 2.5 to 2.5.1, because "2.5" executes "ruby 2.5.0preview1" on it.
Current master branch.
https://travis-ci.org/rubychan/coderay/jobs/317173293

```
$ ruby --version
ruby 2.5.0preview1 (2017-10-10 trunk 60153) [x86_64-linux]
```
Also added Ruby 2.6 on Travis, because 2.6.0 preview2 is available now.
https://www.ruby-lang.org/en/
