### PR TITLE
Remove the statement that is not always reached.

### DIFF
--- a/lib/coderay/encoders/html/output.rb
+++ b/lib/coderay/encoders/html/output.rb
@@ -76,8 +76,6 @@ module Encoders
             apply_title! title
           end
           self
-        when nil
-          return self
         else
           raise "Unknown value %p for :wrap" % element
         end


### PR DESCRIPTION
If the `element` is `nil`, it is returned on below line. The `when nil` statement is not always reached.

```
return self if not element or element == wrapped_in
```
