### PR TITLE
java: support for special type 'var'

### DIFF
--- a/lib/coderay/scanners/java.rb
+++ b/lib/coderay/scanners/java.rb
@@ -20,7 +20,7 @@ module Scanners
     MAGIC_VARIABLES = %w[ this super ]  # :nodoc:
     TYPES = %w[
       boolean byte char class double enum float int interface long
-      short void
+      short void var
     ] << '[]'  # :nodoc: because int[] should be highlighted as a type
     DIRECTIVES = %w[
       abstract extends final implements native private protected public


### PR DESCRIPTION
Hello, 

 it would be nice to support the new Java type inference "var". According to the spec [1] "var" is not a keyword but rather a special type identifier. 

This is why I added var to TYPES rather than to KEYWORDS.

[1] see section "3.9" of The Java Language Specification, Java SE 11 Edition (https://docs.oracle.com/javase/specs/jls/se11/html/jls-3.html#jls-3.9)