### PR TITLE
java: non keywords

### DIFF
--- a/lib/coderay/scanners/java.rb
+++ b/lib/coderay/scanners/java.rb
@@ -12,8 +12,7 @@ module Scanners
     KEYWORDS = %w[
       assert break case catch continue default do else
       finally for if instanceof import new package
-      return switch throw try typeof while
-      debugger export
+      return switch throw try while
     ]  # :nodoc:
     RESERVED = %w[ const goto ]  # :nodoc:
     CONSTANTS = %w[ false null true ]  # :nodoc:


### PR DESCRIPTION
Hello,

  while looking for references to fix #229 I spotted these additional keywords in the Java scanner.
I cannot find **export** nor **typeof** nor **debugger** anywhere in:
https://docs.oracle.com/javase/specs/jls/se11/html/jls-3.html#jls-3.9