### PR TITLE
Add Ruby 2.6 fixing issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ rvm:
   - 2.3
   - 2.4.2
   - 2.5
+  - 2.6
   - ruby-head
   - jruby
 branches:
@@ -20,7 +21,6 @@ before_script:
 - if (ruby -e "exit RUBY_VERSION.to_f >= 2.3"); then export RUBYOPT="--enable-frozen-string-literal"; fi; echo $RUBYOPT
 matrix:
   allow_failures:
-    - rvm: 2.5
     - rvm: ruby-head
     - rvm: jruby
 script: "rake test" # test:scanners"

--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,5 @@ group :development do
   gem 'shoulda-context',  RUBY_VERSION < '1.9' ? '= 1.2.1'    : '>= 1.2.1'
   gem 'test-unit',        RUBY_VERSION < '1.9' ? '~> 2.0'     : '>= 3.0'
   gem 'json', '>= 1.8' if RUBY_VERSION < '1.9'
-  gem 'rdoc',             RUBY_VERSION < '1.9' ? '~> 4.2.2'   : '>= 4.2.2'
+  gem 'rdoc',             Gem::Version.new(RUBY_VERSION) < Gem::Version.new('1.9.3') ? '~> 4.2.2' : Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.2.2') ? '< 6' : '>= 6'
 end

--- a/lib/coderay/tokens.rb
+++ b/lib/coderay/tokens.rb
@@ -39,6 +39,9 @@ module CodeRay
   # You can serialize it to a JSON string and store it in a database, pass it
   # around to encode it more than once, send it to other algorithms...
   class Tokens < Array
+    # Remove Array#filter that is a new alias for Array#select on Ruby 2.6,
+    # for method_missing called with filter method.
+    undef_method :filter if instance_methods.include?(:filter)
     
     # The Scanner instance that created the tokens.
     attr_accessor :scanner

--- a/test/unit/filter.rb
+++ b/test/unit/filter.rb
@@ -18,6 +18,7 @@ class FilterTest < Test::Unit::TestCase
       tokens.text_token i.to_s, :index
     end
     assert_equal tokens, CodeRay::Encoders::Filter.new.encode_tokens(tokens)
+    assert_equal CodeRay::Tokens, tokens.filter.class
     assert_equal tokens, tokens.filter
   end
   
@@ -32,6 +33,7 @@ class FilterTest < Test::Unit::TestCase
       tokens.end_line :index
     end
     assert_equal tokens, CodeRay::Encoders::Filter.new.encode_tokens(tokens)
+    assert_equal CodeRay::Tokens, tokens.filter.class
     assert_equal tokens, tokens.filter
   end
   


### PR DESCRIPTION
* Remove existing Tokens#filter (Array#filter) for Ruby 2.6 compatibility.
* Install proper version's rdoc considering installed Ruby version.

This PR is for Ruby 2.6 compatibility.

As Array#filter is a new alias for Array#select on Ruby 2.6, we need to remove the method in Tokens.
https://github.com/ruby/ruby/blob/trunk/doc/NEWS-2.6.0

I added 2 assertions, because Enumerate#filter returns `Enumerate` object not `Tokens` object when we does not remove Enumerate#filter.
