### PR TITLE
Fix rubygems deprecation

### DIFF
--- a/coderay.gemspec
+++ b/coderay.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
   
-  s.rubyforge_project = s.name
   s.rdoc_options      = '-SNw2', "-m#{readme_file}", '-t CodeRay Documentation'
   s.extra_rdoc_files  = readme_file
 end


### PR DESCRIPTION
```
NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.
Gem::Specification#rubyforge_project= called from /home/deivid/.rbenv/versions/2.4.9/lib/ruby/gems/2.4.0/specifications/coderay-1.1.2.gemspec:21.
```