### PR TITLE
Don't leak a global variable

### DIFF
--- a/lib/coderay/scanners/ruby.rb
+++ b/lib/coderay/scanners/ruby.rb
@@ -257,7 +257,7 @@ module Scanners
               end
               unless unicode
                 # check for unicode
-                $DEBUG_BEFORE, $DEBUG = $DEBUG, false
+                debug_before, $DEBUG = $DEBUG, false
                 begin
                   if check(/./mu).size > 1
                     # seems like we should try again with unicode
@@ -266,7 +266,7 @@ module Scanners
                 rescue
                   # bad unicode char; use getch
                 ensure
-                  $DEBUG = $DEBUG_BEFORE
+                  $DEBUG = debug_before
                 end
                 next if unicode
               end


### PR DESCRIPTION
While debugging in a pry console, I noticed there was a `$DEBUG_BEFORE` global variable and I tracked it down to here.

It's not necessary to use a global variable to store the previous value of `$DEBUG`. Since it's in the same scope, a local variable is enough.