### PR TITLE
Remove invalid -S option from rdoc_options

### DIFF
--- a/coderay.gemspec
+++ b/coderay.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
   
-  s.rdoc_options      = '-SNw2', "-m#{readme_file}", '-t CodeRay Documentation'
+  s.rdoc_options      = '-Nw2', "-m#{readme_file}", '-t CodeRay Documentation'
   s.extra_rdoc_files  = readme_file
 end


### PR DESCRIPTION
The "-S" option for `rdoc_options` is invalid:

```
>gem install coderay-1.1.3.rc1.gem
Successfully installed coderay-1.1.3.rc1
invalid options: -SNw2
(invalid options are ignored)
```

This PR removes it.

Addresses https://github.com/rubychan/coderay/issues/235