### PR TITLE
Fix test suite for ruby 3.0 change for methods on subclass of Array

### DIFF
--- a/test/unit/debug.rb
+++ b/test/unit/debug.rb
@@ -24,7 +24,8 @@ class DebugEncoderTest < Test::Unit::TestCase
     ["   \n", :space],
     ["[]", :method],
     [:end_line, :head],
-  ].flatten
+  ]
+  TEST_INPUT.flatten!
   TEST_OUTPUT = <<-'DEBUG'.chomp
 integer(10)operator((\\\))string<content(test)>head[
 

--- a/test/unit/statistic.rb
+++ b/test/unit/statistic.rb
@@ -24,7 +24,8 @@ class StatisticEncoderTest < Test::Unit::TestCase
     ["   \n", :space],
     ["[]", :method],
     [:end_line, :test],
-  ].flatten
+  ]
+  TEST_INPUT.flatten!
   TEST_OUTPUT = <<-'DEBUG'
 
 Code Statistics


### PR DESCRIPTION
With ruby 3.0, especially with https://github.com/ruby/ruby/pull/3690 ,
for subclass of Array, `flatten` method now returns the instance of Array,
not of the subclass.

To keep the object instance of the subclass, use `flatten!` instead.

Fixes #254 